### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(MEMOS)
 set(EXTENSION_HOMEPAGE "https://github.com/SlicerMorph/SlicerMEMOS")
 set(EXTENSION_CATEGORY "Segmentation")
 set(EXTENSION_CONTRIBUTORS "Sara Rolfe (SCRI), Murat Maga (SCRI, UW)")
-set(EXTENSION_DESCRIPTION "This model loads a PyTorch Deep Learning model and predicts a segmentation with 50 labeled regions for a fetal mouse scan volume.")
+set(EXTENSION_DESCRIPTION "This extension enables deep learning-powered segmentation of 50 anatomical structures from microCT scans of embryonic mice.")
 set(EXTENSION_ICONURL "https://github.com/SlicerMorph/SlicerMEMOS/raw/main/MEMOS/Resources/Icons/MEMOS.png")
 set(EXTENSION_SCREENSHOTURLS "https://github.com/SlicerMorph/SlicerMEMOS/raw/main/memos.jpg")
 set(EXTENSION_DEPENDS "PyTorch") # Specified as a list or "NA" if no dependencies


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.